### PR TITLE
Typo Unit Description

### DIFF
--- a/units/ferret.lua
+++ b/units/ferret.lua
@@ -18,7 +18,7 @@ return {
 		collide = false,
 		cruisealt = 60,
 		defaultmissiontype = "VTOL_standby",
-		description = "Land Atack  Helicopter",
+		description = "Land Attack Helicopter",
 		energymake = 0.8,
 		energystorage = 0,
 		energyuse = 1,


### PR DESCRIPTION
Word "Atack"is missing a "t".
There are 2 spaces between words "Atack" and "Helicopter".