### PR TITLE
Typo Unit Description

### DIFF
--- a/units/ahermes.lua
+++ b/units/ahermes.lua
@@ -18,7 +18,7 @@ return {
 		category = "ALL MOBILE NOTDEFENSE NOTHOVERNOTVTOL NOTSUB NOTSUBNOTSHIP NOTVTOL SMALL WEAPON",
 		corpse = "dead",
 		defaultmissiontype = "Standby",
-		description = "Anti-Air Misile tank",
+		description = "Anti-Air Missile Tank",
 		energymake = 0.5,
 		energystorage = 0,
 		energyuse = 0.5,


### PR DESCRIPTION
The "Misile" is missing a "s".
Word "tank" should start with big "T".