### PR TITLE
Typo Unit Description

### DIFF
--- a/units/tlllongshot.lua
+++ b/units/tlllongshot.lua
@@ -16,7 +16,7 @@ return {
 		category = "ALL HUGE MEDIUM MOBILE NOTDEFENSE NOTHOVERNOTVTOL NOTSUB NOTSUBNOTSHIP NOTVTOL WEAPON",
 		corpse = "dead",
 		defaultmissiontype = "Standby",
-		description = "Long Range EMP Paralizer Tank",
+		description = "Long Range EMP Paralyser Tank",
 		energymake = 1,
 		energystorage = 0,
 		energyuse = 0,


### PR DESCRIPTION
Only exception in TLL with "Paralizer",
so "iz", instead "Paralyser" with "ys".