### PR TITLE
Delete a Word in the Unit Description

### DIFF
--- a/units/watcher.lua
+++ b/units/watcher.lua
@@ -16,7 +16,7 @@ return {
 		category = "ALL HOVER MOBILE NOTDEFENSE NOTSUB NOTSUBNOTSHIP NOTVTOL NOTWEAPON SMALL",
 		corpse = "dead",
 		defaultmissiontype = "Standby",
-		description = "Batlefield Radar and Sonar Hovercraft",
+		description = "Radar and Sonar Hovercraft",
 		downloadable = 1,
 		energymake = 15,
 		energystorage = 0,


### PR DESCRIPTION
Word "Batlefield" misses a "t" but better remove the word
completly since all units are, of course, on the battlefield.
If you wanna keep "Battlefield" i will just make a pull request for the "t"