### PR TITLE
Change punctuation marks in Unit Description

### DIFF
--- a/units/tllarchnano.lua
+++ b/units/tllarchnano.lua
@@ -17,7 +17,7 @@ return {
 		category = "ALL MEDIUM MOBILE NOTDEFENSE NOTHOVERNOTVTOL NOTSUB NOTSUBNOTSHIP NOTVTOL NOTWEAPON",
 		corpse = "dead",
 		defaultmissiontype = "Standby",
-		description = "Ampibious & All Terrain Combat Engineer",
+		description = "Ampibious All-Terrain Combat Engineer",
 		energymake = 5,
 		energyuse = 0,
 		explodeas = "BIG_UNITEX",


### PR DESCRIPTION
All Terrain is missing a "-" since all
other units got written "All-Terrain".
I would skip the "&".