### PR TITLE
Air Trans Description

### DIFF
--- a/units/armor.lua
+++ b/units/armor.lua
@@ -19,7 +19,7 @@ return {
 		category = "ALL MOBILE NOTDEFENSE NOTSUB NOTSUBNOTSHIP NOTWEAPON VTOL",
 		cruisealt = 250,
 		defaultmissiontype = "VTOL_standby",
-		description = "Very Heavy Air Transport, Min load 2000 - Max Load 15000",
+		description = "Very Heavy Air Transport",
 		energymake = 0.6,
 		energystorage = 0,
 		energyuse = 0.6,

--- a/units/corbtrans.lua
+++ b/units/corbtrans.lua
@@ -19,7 +19,7 @@ return {
 		category = "ALL MOBILE NOTDEFENSE NOTSUB NOTSUBNOTSHIP NOTWEAPON VTOL",
 		cruisealt = 250,
 		defaultmissiontype = "VTOL_standby",
-		description = "Very Heavy Air Transport, Min load 2000 - Max Load 16000",
+		description = "Very Heavy Air Transport",
 		energymake = 0,
 		energystorage = 0,
 		energyuse = 0,


### PR DESCRIPTION
I would delete "Min load 2000 - Max Load 15000"
for "Ornith" and "Vindicator".

If not would be cool to have the load info for all
Air Trans from all Factions.
The word "load" should start with big "L" for
"Vindicator" and "Ornith".
Write "Load 2000 - 15000" to shorten it cause
min/max is kinda obvious?


"Atlas - Air Transport" Arm T1 Air
"Drillerfly - Medium Amphibious Air Transport" Arm T1.5 Air
"Dragonfly - Stealthy Armed Transport" Arm T2 Air
"Ornith - Very Heavy Air Transport, Min load 2000 - Max Load 15000" Arm T3 Air

"Valkyrie - Air Transport" Core T1 Air
"Falcon - Medium Amphibious Air Transport" Core T1.5 Air
"Seahook - Assault Transport"	 Core T2 Air
"Vindicator - Very Heavy Air Transport, Min load 2000 - Max Load 16000" Core T3 Air

"Zergon - Air Transport" TLL T1 Air
"Robber - Heavy Armored Air Transport" TLL T2 Air