### PR TITLE
Update armarty.lua

### DIFF
--- a/units/armarty.lua
+++ b/units/armarty.lua
@@ -15,7 +15,7 @@ return {
 		category = "ALL MEDIUM MOBILE NOTDEFENSE NOTHOVERNOTVTOL NOTSUB NOTSUBNOTSHIP NOTVTOL WEAPON",
 		corpse = "dead",
 		defaultmissiontype = "Standby",
-		description = "Level 1 Artillery",
+		description = "Light Artillery",
 		downloadable = 1,
 		energymake = 0.3,
 		energystorage = 0,


### PR DESCRIPTION
"Gladius - Level 1 Artillery" Arm T1 Vehicle
Other units got definitions like "Light/Medium/Heavy"
but i didn't see such thing like "Level 1".