### PR TITLE
Balance storage extractor

### DIFF
--- a/units/armamex.lua
+++ b/units/armamex.lua
@@ -32,7 +32,7 @@ return {
 		maxslope = 20,
 		maxvelocity = 0,
 		maxwaterdepth = 0,
-		metalstorage = 50,
+		metalstorage = 25,
 		mincloakdistance = 66,
 		name = "Twilight",
 		noautofire = false,

--- a/units/armamex.lua
+++ b/units/armamex.lua
@@ -32,7 +32,7 @@ return {
 		maxslope = 20,
 		maxvelocity = 0,
 		maxwaterdepth = 0,
-		metalstorage = 75,
+		metalstorage = 50,
 		mincloakdistance = 66,
 		name = "Twilight",
 		noautofire = false,

--- a/units/armmex.lua
+++ b/units/armmex.lua
@@ -33,7 +33,7 @@ return {
 		maxslope = 20,
 		maxvelocity = 0,
 		maxwaterdepth = 20,
-		metalstorage = 50,
+		metalstorage = 25,
 		name = "Metal Extractor",
 		noautofire = false,
 		nochasecategory = "ALL",

--- a/units/armmex1.lua
+++ b/units/armmex1.lua
@@ -33,7 +33,7 @@ return {
 		maxslope = 20,
 		maxvelocity = 0,
 		maxwaterdepth = 9999,
-		metalstorage = 300,
+		metalstorage = 50,
 		name = "Metal Extractor",
 		noautofire = false,
 		nochasecategory = "ALL",

--- a/units/armmoho.lua
+++ b/units/armmoho.lua
@@ -30,7 +30,7 @@ return {
 		maxslope = 20,
 		maxvelocity = 0,
 		maxwaterdepth = 20,
-		metalstorage = 1000,
+		metalstorage = 500,
 		name = "Moho Mine",
 		noautofire = false,
 		nochasecategory = "ALL",

--- a/units/armuwmex.lua
+++ b/units/armuwmex.lua
@@ -29,7 +29,7 @@ return {
 		maxdamage = 180,
 		maxslope = 24,
 		maxvelocity = 0,
-		metalstorage = 50,
+		metalstorage = 25,
 		minwaterdepth = 15,
 		name = "Underwater Metal Extractor",
 		noautofire = false,

--- a/units/armuwmme.lua
+++ b/units/armuwmme.lua
@@ -29,7 +29,7 @@ return {
 		maxdamage = 2050,
 		maxslope = 24,
 		maxvelocity = 0,
-		metalstorage = 1000,
+		metalstorage = 500,
 		minwaterdepth = 15,
 		name = "Underwater Moho Mine",
 		noautofire = false,

--- a/units/corexp.lua
+++ b/units/corexp.lua
@@ -35,7 +35,7 @@ return {
 		maxslope = 20,
 		maxvelocity = 0,
 		maxwaterdepth = 0,
-		metalstorage = 75,
+		metalstorage = 25,
 		name = "Exploiter",
 		noautofire = false,
 		nochasecategory = "ALL",

--- a/units/cormex.lua
+++ b/units/cormex.lua
@@ -34,7 +34,7 @@ return {
 		maxslope = 20,
 		maxvelocity = 0,
 		maxwaterdepth = 20,
-		metalstorage = 50,
+		metalstorage = 25,
 		name = "Metal Extractor",
 		noautofire = false,
 		nochasecategory = "ALL",

--- a/units/cormex1.lua
+++ b/units/cormex1.lua
@@ -34,7 +34,7 @@ return {
 		maxslope = 20,
 		maxvelocity = 0,
 		maxwaterdepth = 9999,
-		metalstorage = 100,
+		metalstorage = 50,
 		name = "Metal Extractor",
 		noautofire = false,
 		nochasecategory = "ALL",

--- a/units/cormex1.lua
+++ b/units/cormex1.lua
@@ -34,7 +34,7 @@ return {
 		maxslope = 20,
 		maxvelocity = 0,
 		maxwaterdepth = 9999,
-		metalstorage = 300,
+		metalstorage = 100,
 		name = "Metal Extractor",
 		noautofire = false,
 		nochasecategory = "ALL",

--- a/units/cormoho.lua
+++ b/units/cormoho.lua
@@ -31,7 +31,7 @@ return {
 		maxslope = 20,
 		maxvelocity = 0,
 		maxwaterdepth = 20,
-		metalstorage = 250,
+		metalstorage = 500,
 		name = "Moho Mine",
 		noautofire = false,
 		nochasecategory = "ALL",

--- a/units/cormoho.lua
+++ b/units/cormoho.lua
@@ -31,7 +31,7 @@ return {
 		maxslope = 20,
 		maxvelocity = 0,
 		maxwaterdepth = 20,
-		metalstorage = 1000,
+		metalstorage = 250,
 		name = "Moho Mine",
 		noautofire = false,
 		nochasecategory = "ALL",

--- a/units/coruwmex.lua
+++ b/units/coruwmex.lua
@@ -29,7 +29,7 @@ return {
 		maxdamage = 185,
 		maxslope = 20,
 		maxvelocity = 0,
-		metalstorage = 50,
+		metalstorage = 25,
 		minwaterdepth = 15,
 		name = "Underwater Metal Extractor",
 		noautofire = false,

--- a/units/coruwmme.lua
+++ b/units/coruwmme.lua
@@ -30,7 +30,7 @@ return {
 		maxdamage = 2075,
 		maxslope = 24,
 		maxvelocity = 0,
-		metalstorage = 1000,
+		metalstorage = 500,
 		minwaterdepth = 15,
 		name = "Underwater Moho Mine",
 		noautofire = false,

--- a/units/tllamex.lua
+++ b/units/tllamex.lua
@@ -27,7 +27,7 @@ return {
 		maxdamage = 3557,
 		maxslope = 10,
 		maxwaterdepth = 0,
-		metalstorage = 1250,
+		metalstorage = 750,
 		name = "Moho Mine",
 		noautofire = false,
 		nochasecategory = "ALL",

--- a/units/tllauwmex.lua
+++ b/units/tllauwmex.lua
@@ -27,6 +27,7 @@ return {
 		mass = 800,
 		maxdamage = 3300,
 		maxslope = 24,
+		metalstorage = 750,
 		minwaterdepth = 20,
 		name = "Advanced Underwater Mex",
 		noautofire = false,

--- a/units/tllmex.lua
+++ b/units/tllmex.lua
@@ -31,7 +31,7 @@ return {
 		maxdamage = 232,
 		maxslope = 12,
 		maxwaterdepth = 0,
-		metalstorage = 70,
+		metalstorage = 35,
 		name = "Metal Extractor",
 		noautofire = false,
 		nochasecategory = "ALL",

--- a/units/tllmex1.lua
+++ b/units/tllmex1.lua
@@ -31,7 +31,7 @@ return {
 		maxdamage = 760,
 		maxslope = 20,
 		maxwaterdepth = 9999,
-		metalstorage = 300,
+		metalstorage = 75,
 		name = "Metal Extractor",
 		noautofire = false,
 		nochasecategory = "ALL",

--- a/units/tlluwmex.lua
+++ b/units/tlluwmex.lua
@@ -23,6 +23,7 @@ return {
 		mass = 58,
 		maxdamage = 220,
 		maxslope = 24,
+		metalstorage = 35,
 		minwaterdepth = 20,
 		name = "Underwater Metal Extractor",
 		noautofire = false,


### PR DESCRIPTION
TLL underwater had not storage. Added.
All T1 T1.5 and T2 decrease by 50%. 
Goal is to see more often T1 T2 Metal Storage.
TLL have +50% storage vs ARM CORE. (T1 35 vs 25 ARM CORE)
Didn't change T3
