### PR TITLE
Default disable Mouse Over Unit Stats

### DIFF
--- a/luaui/widgets/gui_mouseover_unit_stats.lua
+++ b/luaui/widgets/gui_mouseover_unit_stats.lua
@@ -8,7 +8,7 @@ function widget:GetInfo()
 		version   = 1.6,
 		license   = "GNU GPL, v2 or later",
 		layer     = -9999999999,
-		enabled   = true,  --  loaded by default?
+		enabled   = false,  --  loaded by default?
 	}
 end
 


### PR DESCRIPTION
Some ppl complaining that it cover too much space, and its annoying
Pls vote for disable or not.