### PR TITLE
Remove 'taken the lead' kills/damage announcements

### DIFF
--- a/luarules/gadgets/gui_best_damage.lua
+++ b/luarules/gadgets/gui_best_damage.lua
@@ -9,7 +9,7 @@ function gadget:GetInfo()
 		date = "14 june 2011",
 		license = "Free",
 		layer = 0,
-		enabled = true
+		enabled = false
 	}
 end
 


### PR DESCRIPTION
Decrease redundant info that is available in Stats top menu.