### PR TITLE
Rename tllzeppelin.lua

### DIFF
--- a/units/tllzeppelin.lua
+++ b/units/tllzeppelin.lua
@@ -39,7 +39,7 @@ return {
 		maxvelocity = 0.95,
 		maxwaterdepth = 255,
 		metalstorage = 1000,
-		name = "Zeppelin",
+		name = "Dory",
 		nochasecategory = "SUB VTOL",
 		objectname = "tllzeppelin",
 		radardistance = 0,


### PR DESCRIPTION
 i think the lost legacy zepelin should be renamed
[22:51:21] <[KING]skymyj> why?
[22:51:47] <Thorgasm> a name that hints towrds thrusting would subconsciously make users use their forward blue beam often
[22:51:51] <Thorgasm> like a spearhead
[22:52:00] <Thorgasm> consdiering tll tanks such as gladius exists
[22:52:11] <Thorgasm> thematrically classical age weapons can fit well
[22:53:01] <Thorgasm> although i would not recommend the name "Asparagus"
[22:53:26] <Thorgasm> but i would think it would be funny to kill people with a unit called asparagus
[22:53:36] <[KING]skymyj> :)
[22:54:03] <[KING]AutoHost4> <[teh]Lucy> !cv stop op take
[22:55:09] <Thorgasm> https://en.wikipedia.org/wiki/Dory_(spear)