### PR TITLE
Add badtargetcategory to abroadside

### DIFF
--- a/units/abroadside.lua
+++ b/units/abroadside.lua
@@ -194,16 +194,19 @@ return {
 		},
 		weapons = {
 			[1] = {
+				badtargetcategory = "SMALL TINY",
 				def = "750MW",
 				onlytargetcategory = "SURFACE",
 			},
 			[2] = {
+				badtargetcategory = "SMALL TINY",
 				def = "750MW",
 				maindir = "0 0 1",
 				maxangledif = 270,
 				onlytargetcategory = "SURFACE",
 			},
 			[3] = {
+				badtargetcategory = "SMALL TINY",
 				def = "750MW",
 				maindir = "0 0 -1",
 				maxangledif = 270,
@@ -222,6 +225,7 @@ return {
 				onlytargetcategory = "VTOL",
 			},
 			[6] = {
+				badtargetcategory = "SMALL TINY",
 				def = "750MW",
 				maindir = "0 0 1",
 				maxangledif = 270,


### PR DESCRIPTION
ATM, they can't fight other T4/T5 units correctly if you send scout spam too