### PR TITLE
Fix lups_nano_spray gadget

### DIFF
--- a/luarules/gadgets/lups_nano_spray.lua
+++ b/luarules/gadgets/lups_nano_spray.lua
@@ -284,6 +284,7 @@ function gadget:GameFrame(frame)
             break
         end
 		local unitID = builders[i]
+	if tonumber(unitID) then
 		local UnitDefID = Spring.GetUnitDefID(unitID)
 		local buildpower = builderWorkTime[UnitDefID] or 1
     	if ((unitID + frame) % updateFramerate < 1) then
@@ -376,6 +377,7 @@ function gadget:GameFrame(frame)
 				end
 			end
 		end
+	end
 	end --//for
 	--Spring.Echo(frame..'  '..totalNanoEmitters)
 end


### PR DESCRIPTION
[f=0087144] Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=GameFrame trace=[Internal Lua error: Call failure] [string "LuaRules/Gadgets/lups_nano_spray.lua"]:297: IsUnitIcon(): unitID not a number
stack traceback:
	[C]: in function 'IsUnitIcon'
	[string "LuaRules/Gadgets/lups_nano_spray.lua"]:297: in function 'GameFrame'
	[string "LuaRules/gadgets.lua"]:880: in function <[string "LuaRules/gadgets.lua"]:878>
	(tail call): ?