### PR TITLE
Target priority rewrite

### DIFF
--- a/luarules/gadgets/unit_targetting_priorities.lua
+++ b/luarules/gadgets/unit_targetting_priorities.lua
@@ -20,7 +20,9 @@ if gadgetHandler:IsSyncedCode() then
     local SetUnitRulesParam = Spring.SetUnitRulesParam
     local GetUnitRulesParam = Spring.GetUnitRulesParam
     local GetUnitTeam = Spring.GetUnitTeam
+    local SendMessageToTeam = Spring.SendMessageToTeam
     local CMD_SET_PRIORITY = 34567
+    local redcolor = "\255\255\64\64"
     local PRIORITY_GOOD = 0.001
     local PRIORITY_BAD = 100
     local PRIORITY_INDIFFERENT = 1
@@ -409,6 +411,7 @@ if gadgetHandler:IsSyncedCode() then
             end
             if GetUnitRulesParam(unitID, "priorityEnabled") == 0 and cmdParams and cmdParams[1] ~= NO_PRIORITY_INDEX then -- change to prioritising
                 if playerPriorityCount[team] >= PLAYER_PRIORITY_LIMIT then
+                    SendMessageToTeam(team, redcolor .. "Warning: Can not set priority, limit ("..PLAYER_PRIORITY_LIMIT..") reached")
                     return false
                 end
                 playerPriorityCount[team] = playerPriorityCount[team] + 1

--- a/luarules/gadgets/unit_targetting_priorities.lua
+++ b/luarules/gadgets/unit_targetting_priorities.lua
@@ -16,12 +16,33 @@ if gadgetHandler:IsSyncedCode() then
     local EditUnitCmdDesc = Spring.EditUnitCmdDesc
     local FindUnitCmdDesc = Spring.FindUnitCmdDesc
     local GetUnitDefID = Spring.GetUnitDefID
-    local GetUnitRulesParam = Spring.GetUnitRulesParam
     local InsertUnitCmdDesc = Spring.InsertUnitCmdDesc
     local SetUnitRulesParam = Spring.SetUnitRulesParam
+    local GetUnitRulesParam = Spring.GetUnitRulesParam
+    local GetUnitTeam = Spring.GetUnitTeam
     local CMD_SET_PRIORITY = 34567
+    local PRIORITY_GOOD = 0.001
+    local PRIORITY_BAD = 100
+    local PRIORITY_INDIFFERENT = 1
+    local PRIORITY_MUST_NOT = -1
 
-    local setPriorityAirn = {
+    local NO_PRIORITY_INDEX = 0
+
+    local unitToPriorityMap = {}
+    local playerPriorityCount = {}
+    local PLAYER_PRIORITY_LIMIT
+    -- maybe the modoptions should be available as a global table
+    -- which also uses the modoption keys as keys
+    for _, v in pairs(VFS.Include("modoptions.lua")) do
+        if v.key == "mo_priority_unit_limit" then
+            PLAYER_PRIORITY_LIMIT = v.def
+            break
+        end
+    end
+    local limitOption = Spring.GetModOptions().mo_priority_unit_limit
+    PLAYER_PRIORITY_LIMIT = limitOption and tonumber(limitOption) or PLAYER_PRIORITY_LIMIT
+
+    local setPriorityAirNone = {
         id = CMD_SET_PRIORITY,
         type = CMDTYPE.ICON_MODE,
         name = 'Set Priority',
@@ -31,7 +52,7 @@ if gadgetHandler:IsSyncedCode() then
         params = {'0', 'No priority', '', '', '', ''}
     }
 
-    local setPriorityAirf = {
+    local setPriorityAirFighter = {
         id = CMD_SET_PRIORITY,
         type = CMDTYPE.ICON_MODE,
         name = 'Set Priority',
@@ -41,7 +62,7 @@ if gadgetHandler:IsSyncedCode() then
         params = {'1', '', 'Fighters', '', '', ''}
     }
 
-    local setPriorityAirb = {
+    local setPriorityAirBomber = {
         id = CMD_SET_PRIORITY,
         type = CMDTYPE.ICON_MODE,
         name = 'Set Priority',
@@ -51,7 +72,7 @@ if gadgetHandler:IsSyncedCode() then
         params = {'2', '', '', 'Bombers', '', ''}
     }
 
-    local setPriorityAirOb = {
+    local setPriorityAirOnlyBomber = {
         id = CMD_SET_PRIORITY,
         type = CMDTYPE.ICON_MODE,
         name = 'Set Priority',
@@ -61,7 +82,7 @@ if gadgetHandler:IsSyncedCode() then
         params = {'3', '', '', '', '\255\255\64\64Only\n Bombers', ''}
     }
 
-    local setPriorityAirNs = {
+    local setPriorityAirNoScouts = {
         id = CMD_SET_PRIORITY,
         type = CMDTYPE.ICON_MODE,
         name = 'Set Priority',
@@ -71,200 +92,357 @@ if gadgetHandler:IsSyncedCode() then
         params = {'4', '', '', '', '', '\255\64\170\255No Scouts'}
     }
 
-    local AAunits = {}
-
-    airCategories = {
-        --Transporters
-        [UnitDefNames["armatlas"].id] = "Bombers",
-        [UnitDefNames["armdfly"].id] = "Bombers",
-        [UnitDefNames["talon_wyvern"].id] = "Bombers",
-        [UnitDefNames["talon_rukh"].id] = "Bombers",
-        [UnitDefNames["talon_tau"].id] = "Bombers",
-        [UnitDefNames["armsl"].id] = "Bombers",
-        [UnitDefNames["corvalk"].id] = "Bombers",
-        [UnitDefNames["tllrobber"].id] = "Bombers",
-        [UnitDefNames["tlltplane"].id] = "Bombers",
-        [UnitDefNames["armor"].id] = "Bombers",
-        [UnitDefNames["tllbtrans"].id] = "Bombers",
-        [UnitDefNames["cormuat"].id] = "Bombers",
-        --Bombers
-        [UnitDefNames["talon_cyclone"].id] = "Bombers",
-        [UnitDefNames["talon_shade"].id] = "Bombers",
-        [UnitDefNames["talon_eclipse"].id] = "Bombers",
-        [UnitDefNames["talon_handgod"].id] = "Bombers",
-        [UnitDefNames["talon_trident"].id] = "Bombers",
-        [UnitDefNames["armcybr"].id] = "Bombers",
-        [UnitDefNames["armlance"].id] = "Bombers",
-        [UnitDefNames["armpnix"].id] = "Bombers",
-        [UnitDefNames["armsb"].id] = "Bombers",
-        [UnitDefNames["armthund"].id] = "Bombers",
-        [UnitDefNames["armcyclone"].id] = "Bombers",
-        [UnitDefNames["corgripn"].id] = "Bombers",
-        [UnitDefNames["corhurc"].id] = "Bombers",
-        [UnitDefNames["corsb"].id] = "Bombers",
-        [UnitDefNames["corshad"].id] = "Bombers",
-        [UnitDefNames["cortitan"].id] = "Bombers",
-        [UnitDefNames["tllabomber"].id] = "Bombers",
-        [UnitDefNames["tllbomber"].id] = "Bombers",
-        [UnitDefNames["tlltorpp"].id] = "Bombers",
-        [UnitDefNames["coreclipse"].id] = "Bombers",
-        [UnitDefNames["tllseab"].id] = "Bombers",
-        [UnitDefNames["corseap"].id] = "Bombers",
-        [UnitDefNames["armseap"].id] = "Bombers",
-        [UnitDefNames["corsbomb"].id] = "Bombers",
-        [UnitDefNames["armorion"].id] = "Bombers",
-        [UnitDefNames["tllanhur"].id] = "Bombers",
-        [UnitDefNames["tllaether"].id] = "Bombers",
-        [UnitDefNames["airwolf3g"].id] = "Fighters",
-        [UnitDefNames["armfig"].id] = "Fighters",
-        [UnitDefNames["armhawk"].id] = "Fighters",
-        [UnitDefNames["armsfig"].id] = "Fighters",
-        [UnitDefNames["corsfig"].id] = "Fighters",
-        [UnitDefNames["corvamp"].id] = "Fighters",
-        [UnitDefNames["corveng"].id] = "Fighters",
-        [UnitDefNames["shrike"].id] = "Fighters",
-        [UnitDefNames["tlladvfight"].id] = "Fighters",
-        [UnitDefNames["tllfight"].id] = "Fighters",
-        [UnitDefNames["tllseaf"].id] = "Fighters",
-        [UnitDefNames["tllshu"].id] = "Fighters",
-        [UnitDefNames["armstratus"].id] = "Fighters",
-        [UnitDefNames["tllcondor"].id] = "Fighters",
-        [UnitDefNames["talon_token"].id] = "Fighters",
-        [UnitDefNames["talon_echelon"].id] = "Fighters",
-        [UnitDefNames["talon_hornet"].id] = "Fighters",
-        --Scouts
-        [UnitDefNames["armpeep"].id] = "Scouts",
-        [UnitDefNames["armawac"].id] = "Scouts",
-        [UnitDefNames["armsehak"].id] = "Scouts",
-        [UnitDefNames["corfink"].id] = "Scouts",
-        [UnitDefNames["corawac"].id] = "Scouts",
-        [UnitDefNames["corhunt"].id] = "Scouts",
-        [UnitDefNames["tllprob"].id] = "Scouts",
-        [UnitDefNames["tllrsplane"].id] = "Scouts",
-        [UnitDefNames["tllsonpl"].id] = "Scouts",
-        [UnitDefNames["talon_recon"].id] = "Scouts",
-        [UnitDefNames["talon_vigilante"].id] = "Scouts",
+    local noPriority = {
+        key = "id",
+        map = {
+            ["_default"] = PRIORITY_INDIFFERENT
+        }
     }
 
-    local function shallow_copy(t)
-        local tmp = {}
+    local fighter = {
+        key = "id",
+        map = {
+            ["_default"] = PRIORITY_BAD,
+            [UnitDefNames["airwolf3g"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armfig"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armhawk"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armsfig"].id] = PRIORITY_GOOD,
+            [UnitDefNames["corsfig"].id] = PRIORITY_GOOD,
+            [UnitDefNames["corvamp"].id] = PRIORITY_GOOD,
+            [UnitDefNames["corveng"].id] = PRIORITY_GOOD,
+            [UnitDefNames["shrike"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tlladvfight"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tllfight"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tllseaf"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tllshu"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armstratus"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tllcondor"].id] = PRIORITY_GOOD,
+            [UnitDefNames["talon_token"].id] = PRIORITY_GOOD,
+            [UnitDefNames["talon_echelon"].id] = PRIORITY_GOOD,
+            [UnitDefNames["talon_hornet"].id] = PRIORITY_GOOD
+        }
+    }
 
-        for k, v in pairs(t) do
-            tmp[k] = v
+    local bomber = {
+        key = "id",
+        map = {
+            ["_default"] = PRIORITY_BAD,
+            [UnitDefNames["armatlas"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armdfly"].id] = PRIORITY_GOOD,
+            [UnitDefNames["talon_wyvern"].id] = PRIORITY_GOOD,
+            [UnitDefNames["talon_rukh"].id] = PRIORITY_GOOD,
+            [UnitDefNames["talon_tau"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armsl"].id] = PRIORITY_GOOD,
+            [UnitDefNames["corvalk"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tllrobber"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tlltplane"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armor"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tllbtrans"].id] = PRIORITY_GOOD,
+            [UnitDefNames["cormuat"].id] = PRIORITY_GOOD,
+            [UnitDefNames["talon_cyclone"].id] = PRIORITY_GOOD,
+            [UnitDefNames["talon_shade"].id] = PRIORITY_GOOD,
+            [UnitDefNames["talon_eclipse"].id] = PRIORITY_GOOD,
+            [UnitDefNames["talon_handgod"].id] = PRIORITY_GOOD,
+            [UnitDefNames["talon_trident"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armcybr"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armlance"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armpnix"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armsb"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armthund"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armcyclone"].id] = PRIORITY_GOOD,
+            [UnitDefNames["corgripn"].id] = PRIORITY_GOOD,
+            [UnitDefNames["corhurc"].id] = PRIORITY_GOOD,
+            [UnitDefNames["corsb"].id] = PRIORITY_GOOD,
+            [UnitDefNames["corshad"].id] = PRIORITY_GOOD,
+            [UnitDefNames["cortitan"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tllabomber"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tllbomber"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tlltorpp"].id] = PRIORITY_GOOD,
+            [UnitDefNames["coreclipse"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tllseab"].id] = PRIORITY_GOOD,
+            [UnitDefNames["corseap"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armseap"].id] = PRIORITY_GOOD,
+            [UnitDefNames["corsbomb"].id] = PRIORITY_GOOD,
+            [UnitDefNames["armorion"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tllanhur"].id] = PRIORITY_GOOD,
+            [UnitDefNames["tllaether"].id] = PRIORITY_GOOD
+        }
+    }
+
+    local bomberOnly = {
+        key = "id",
+        map = {
+            ["_default"] = PRIORITY_MUST_NOT,
+            [UnitDefNames["armatlas"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["armdfly"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["talon_wyvern"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["talon_rukh"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["talon_tau"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["armsl"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["corvalk"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["tllrobber"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["tlltplane"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["armor"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["tllbtrans"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["cormuat"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["talon_cyclone"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["talon_shade"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["talon_eclipse"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["talon_handgod"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["talon_trident"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["armcybr"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["armlance"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["armpnix"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["armsb"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["armthund"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["armcyclone"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["corgripn"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["corhurc"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["corsb"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["corshad"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["cortitan"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["tllabomber"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["tllbomber"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["tlltorpp"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["coreclipse"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["tllseab"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["corseap"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["armseap"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["corsbomb"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["armorion"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["tllanhur"].id] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["tllaether"].id] = PRIORITY_INDIFFERENT
+        }
+    }
+
+    local noScouts = {
+        key = "id",
+        map = {
+            ["_default"] = PRIORITY_INDIFFERENT,
+            [UnitDefNames["armpeep"].id] = PRIORITY_MUST_NOT,
+            [UnitDefNames["armawac"].id] = PRIORITY_MUST_NOT,
+            [UnitDefNames["armsehak"].id] = PRIORITY_MUST_NOT,
+            [UnitDefNames["corfink"].id] = PRIORITY_MUST_NOT,
+            [UnitDefNames["corawac"].id] = PRIORITY_MUST_NOT,
+            [UnitDefNames["corhunt"].id] = PRIORITY_MUST_NOT,
+            [UnitDefNames["tllprob"].id] = PRIORITY_MUST_NOT,
+            [UnitDefNames["tllrsplane"].id] = PRIORITY_MUST_NOT,
+            [UnitDefNames["tllsonpl"].id] = PRIORITY_MUST_NOT,
+            [UnitDefNames["talon_recon"].id] = PRIORITY_MUST_NOT,
+            [UnitDefNames["talon_vigilante"].id] = PRIORITY_MUST_NOT
+        }
+    }
+
+    local airPriorities = {
+        [NO_PRIORITY_INDEX] = {
+            cmdDesc = setPriorityAirNone,
+            map = noPriority
+        },
+        [1] = {
+            cmdDesc = setPriorityAirFighter,
+            map = fighter
+        },
+        [2] = {
+            cmdDesc = setPriorityAirBomber,
+            map = bomber
+        },
+        [3] = {
+            cmdDesc = setPriorityAirOnlyBomber,
+            map = bomberOnly
+        },
+        [4] = {
+            cmdDesc = setPriorityAirNoScouts,
+            map = noScouts
+        }
+    }
+
+    local setPriorityGeneralNone = {
+        id = CMD_SET_PRIORITY,
+        type = CMDTYPE.ICON_MODE,
+        name = 'Set Priority',
+        action = 'setpriority',
+        tooltip = 'Toggle for target priority\nNo current priority set',
+        queueing = false,
+        params = {'0', 'No priority', '', '', '', ''}
+    }
+
+    local setPriorityGeneralStrongest = {
+        id = CMD_SET_PRIORITY,
+        type = CMDTYPE.ICON_MODE,
+        name = 'Set Priority',
+        action = 'setpriority',
+        tooltip = 'Toggle for target priority\nCurrent priority set to most max health',
+        queueing = false,
+        params = {'1', '', 'Strongest', '', '', ''}
+    }
+
+    local setPriorityGeneralAtLeast1k = {
+        id = CMD_SET_PRIORITY,
+        type = CMDTYPE.ICON_MODE,
+        name = 'Set Priority',
+        action = 'setpriority',
+        tooltip = 'Toggle for target priority\nCurrent priority set to only max health greater than 1000',
+        queueing = false,
+        params = {'2', '', '', 'At Least\n1k', '', ''}
+    }
+
+    local setPriorityGeneralAtLeast10k = {
+        id = CMD_SET_PRIORITY,
+        type = CMDTYPE.ICON_MODE,
+        name = 'Set Priority',
+        action = 'setpriority',
+        tooltip = 'Toggle for target priority\nCurrent priority set to only max health greater than 10000',
+        queueing = false,
+        params = {'3', '', '', '', 'At Least\n10k', ''}
+    }
+
+    local setPriorityGeneralAtLeast100k = {
+        id = CMD_SET_PRIORITY,
+        type = CMDTYPE.ICON_MODE,
+        name = 'Set Priority',
+        action = 'setpriority',
+        tooltip = 'Toggle for target priority\nCurrent priority set to only max health greater than 100000',
+        queueing = false,
+        params = {'4', '', '', '', '', 'At Least\n100k'}
+    }
+
+    local healthDescending = {
+        key = "health",
+        map = {} -- empty to trigger __index calls in metatable
+    }
+    local healthDescendingMT = {
+        __index = function (t, k)
+            return 1/k
         end
+    }
+    setmetatable(healthDescending.map, healthDescendingMT)
 
-        return tmp
-    end
+    local healthAtLeast1k = {
+        key = "health",
+        map = {} -- empty to trigger __index calls in metatable
+    }
+    local healthAtLeast1kMT = {
+        __index = function (t, k)
+            return (k < 1000) and PRIORITY_MUST_NOT or PRIORITY_INDIFFERENT
+        end
+    }
+    setmetatable(healthAtLeast1k.map, healthAtLeast1kMT)
 
-    local airCategoriesCached = {}
+    local healthAtLeast10k = {
+        key = "health",
+        map = {} -- empty to trigger __index calls in metatable
+    }
+    local healthAtLeast10kMT = {
+        __index = function (t, k)
+            return (k < 10000) and PRIORITY_MUST_NOT or PRIORITY_INDIFFERENT
+        end
+    }
+    setmetatable(healthAtLeast10k.map, healthAtLeast10kMT)
 
-    function gadget:Initialize()
-        airCategoriesCached = shallow_copy(airCategories)
-    end
+    local healthAtLeast100k = {
+        key = "health",
+        map = {} -- empty to trigger __index calls in metatable
+    }
+    local healthAtLeast100kMT = {
+        __index = function (t, k)
+            return (k < 100000) and PRIORITY_MUST_NOT or PRIORITY_INDIFFERENT
+        end
+    }
+    setmetatable(healthAtLeast100k.map, healthAtLeast100kMT)
+
+    local generalPriorities = {
+        [NO_PRIORITY_INDEX] = {
+            cmdDesc = setPriorityGeneralNone,
+            map = noPriority
+        },
+        [1] = {
+            cmdDesc = setPriorityGeneralStrongest,
+            map = healthDescending
+        },
+        [2] = {
+            cmdDesc = setPriorityGeneralAtLeast1k,
+            map = healthAtLeast1k
+        },
+        [3] = {
+            cmdDesc = setPriorityGeneralAtLeast10k,
+            map = healthAtLeast10k
+        },
+        [4] = {
+            cmdDesc = setPriorityGeneralAtLeast100k,
+            map = healthAtLeast100k
+        }
+    }
+
+    -- prioritytarget in unit definition customParams can be set to the keys in this map
+    --
+    -- index 0 in priority maps MUST be no priority, to enforce limit on prioritising units
+    local priorityTypes = {
+        air = airPriorities,
+        general = generalPriorities
+    }
 
     function gadget:UnitCreated(unitID, unitDefID)
-        local uDef = UnitDefs[unitDefID]
-
-        if uDef.customParams.prioritytarget and uDef.customParams.prioritytarget == "air" then
-            AAunits[unitID] = true
-            InsertUnitCmdDesc(unitID, CMD_SET_PRIORITY, setPriorityAirn)
+        local prioTarget = UnitDefs[unitDefID].customParams.prioritytarget
+        local priorityType = priorityTypes[prioTarget]
+        if priorityType then
+            unitToPriorityMap[unitID] = priorityType[NO_PRIORITY_INDEX].map
+            InsertUnitCmdDesc(unitID, CMD_SET_PRIORITY, priorityType[NO_PRIORITY_INDEX].cmdDesc)
             SetUnitRulesParam(unitID, "priorityEnabled", 0)
         end
     end
 
     function gadget:UnitDestroyed(unitID, unitDefID)
-        if AAunits[unitID] then
-            AAunits[unitID] = nil
+        if unitToPriorityMap[unitID] then
+            if GetUnitRulesParam(unitID, "priorityEnabled") == 1 then -- removed from prioritising
+                local team = GetUnitTeam(unitID)
+                playerPriorityCount[team] = playerPriorityCount[team] - 1
+            end
+            unitToPriorityMap[unitID] = nil
         end
     end
 
     function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
         if cmdID == CMD_SET_PRIORITY then
-            cmdDescId = FindUnitCmdDesc(unitID, CMD_SET_PRIORITY)
-
-            if cmdParams and cmdParams[1] and cmdDescId then
-                if cmdParams[1] == 0 then
-                    EditUnitCmdDesc(unitID, cmdDescId, setPriorityAirn)
-                elseif cmdParams[1] == 1 then
-                    EditUnitCmdDesc(unitID, cmdDescId, setPriorityAirf)
-                elseif cmdParams[1] == 2 then
-                    EditUnitCmdDesc(unitID, cmdDescId, setPriorityAirb)
-                elseif cmdParams[1] == 3 then
-                    EditUnitCmdDesc(unitID, cmdDescId, setPriorityAirOb)
-                elseif cmdParams[1] == 4 then
-                    EditUnitCmdDesc(unitID, cmdDescId, setPriorityAirNs)
+            local team = GetUnitTeam(unitID)
+            if not playerPriorityCount[team] then
+                playerPriorityCount[team] = 0
+            end
+            if GetUnitRulesParam(unitID, "priorityEnabled") == 0 and cmdParams and cmdParams[1] ~= NO_PRIORITY_INDEX then -- change to prioritising
+                if playerPriorityCount[team] >= PLAYER_PRIORITY_LIMIT then
+                    return false
                 end
+                playerPriorityCount[team] = playerPriorityCount[team] + 1
             end
         end
-
         return true
     end
 
     function gadget:UnitCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOpts, cmdTag)
         if cmdID == CMD_SET_PRIORITY then
-            if cmdParams and cmdParams[1] then
-                if cmdParams[1] == 0 then
-                    SetUnitRulesParam(unitID, "priorityEnabled", 0)
-                elseif cmdParams[1] == 1 then
-                    SetUnitRulesParam(unitID, "priorityEnabled", 1)
-                    SetUnitRulesParam(unitID, "targetPriorityFighters", 0.0001)
-                    SetUnitRulesParam(unitID, "targetPriorityBombers", 1)
-                    SetUnitRulesParam(unitID, "targetPriorityOnlyBombers", 0)
-                    SetUnitRulesParam(unitID, "targetPriorityNoSouts", 0)
-                elseif cmdParams[1] == 2 then
-                    SetUnitRulesParam(unitID, "priorityEnabled", 1)
-                    SetUnitRulesParam(unitID, "targetPriorityFighters", 1)
-                    SetUnitRulesParam(unitID, "targetPriorityBombers", 0.0001)
-                    SetUnitRulesParam(unitID, "targetPriorityOnlyBombers", 0)
-                    SetUnitRulesParam(unitID, "targetPriorityNoSouts", 0)
-                elseif cmdParams[1] == 3 then
-                    SetUnitRulesParam(unitID, "priorityEnabled", 1)
-                    SetUnitRulesParam(unitID, "targetPriorityOnlyBombers", 1)
-                    SetUnitRulesParam(unitID, "targetPriorityNoSouts", 0)
-                elseif cmdParams[1] == 4 then
-                    SetUnitRulesParam(unitID, "priorityEnabled", 1)
-                    SetUnitRulesParam(unitID, "targetPriorityFighters", 1)
-                    SetUnitRulesParam(unitID, "targetPriorityBombers", 0.0001)
-                    SetUnitRulesParam(unitID, "targetPriorityOnlyBombers", 0)
-                    SetUnitRulesParam(unitID, "targetPriorityNoSouts", 1)
+            local prioTarget = UnitDefs[unitDefID].customParams.prioritytarget
+            local priorityType = priorityTypes[prioTarget]
+            local cmdDescId = FindUnitCmdDesc(unitID, CMD_SET_PRIORITY)
+            if cmdParams and cmdParams[1] and cmdDescId and priorityType then
+                local i = cmdParams[1]
+                if i == NO_PRIORITY_INDEX and GetUnitRulesParam(unitID, "priorityEnabled") == 1 then -- change to none prioritising
+                    local team = GetUnitTeam(unitID)
+                    playerPriorityCount[team] = playerPriorityCount[team] - 1
                 end
+                unitToPriorityMap[unitID] = priorityType[i].map
+                EditUnitCmdDesc(unitID, cmdDescId, priorityType[i].cmdDesc)
+                SetUnitRulesParam(unitID, "priorityEnabled", (i == NO_PRIORITY_INDEX) and 0 or 1) -- enable calls to AllowWeaponTarget from gadgets.lua
             end
         end
     end
 
+    -- defPriority can be negative or even nil. I suspect engine bugs or faulty unit definitions
     function gadget:AllowWeaponTarget(unitID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
-        local unitDefID = GetUnitDefID(targetID)
-
-        if unitDefID then
-            local allowed = true
-            local priority = defPriority
-
-            if AAunits[unitID] then
-                local priorityEnabled = GetUnitRulesParam(unitID, "priorityEnabled") or 0
-
-                if priorityEnabled == 1 then
-                    local airCat = airCategoriesCached[unitDefID]
-                    local onlyBombers = GetUnitRulesParam(unitID, "targetPriorityOnlyBombers")
-                    local noScouts = GetUnitRulesParam(unitID, "targetPriorityNoSouts")
-                    local hasPriority = (GetUnitRulesParam(unitID, "targetPriorityFighters") and GetUnitRulesParam(unitID, "targetPriorityBombers"))
-
-                    if airCat and hasPriority and onlyBombers == 0 then
-                        if airCat == "Scouts" then
-                            priority = priority * 1000
-
-                            if noScouts == 1 then
-                                allowed = false
-                            end
-                        else
-                            priority = priority * GetUnitRulesParam(unitID, ("targetPriority" .. airCat))
-                        end
-                    elseif airCat and airCat ~= "Bombers" then
-                        allowed = false
-                    end
-                end
-            end
-
-            return allowed, priority
+        local targetDef = UnitDefs[GetUnitDefID(targetID)]
+        local prioritydict = unitToPriorityMap[unitID]
+        if not prioritydict or not targetDef then
+            return true, defPriority or 1
         end
+        local priority = prioritydict.map[targetDef[prioritydict.key]] or prioritydict.map["_default"]
+        return (priority ~= PRIORITY_MUST_NOT), priority * (defPriority or 1)
     end
 end

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -303,5 +303,16 @@ local options={
       {key="none", name="Disallow All", desc="No enemy units can be napped"},
     }
   },
+  {
+    key  = "mo_priority_unit_limit",
+    name = "Priority Unit Limit",
+    desc = "Per player limit on number of units using custom target priorities. Large Values (> 100) may allow lag.\nAutoHost Usage :- mo_priority_unit_limit",
+    type = "number",
+    section = "ta_options",
+    def  = 20,
+    min  = 0,
+    max  = 10000,
+    step = 1,
+  },
 }
 return options


### PR DESCRIPTION
Replace complex priority evaluation by sequence of table lookups.
Generalise priority maps to allow arbitrary unit definition members
as criteria.
Limit per player number of units using priorities to avoid lag.