### PR TITLE
Temporary disable tankanotor due to heavy script errors

### DIFF
--- a/units/armavp.lua
+++ b/units/armavp.lua
@@ -74,7 +74,7 @@ return {
 			[14] = "armhorg",
 			--[15] = "armscpion",
 			--[16] = "armcd",
-			[17] = "tankanotor",
+			--[17] = "tankanotor", - temporary disable
 		},
 		customparams = {
 			buildpic = "armavp.dds",


### PR DESCRIPTION
```
[f=0043154] Warning: [MapScriptToModelPieces] could not find piece named "flare1" (referenced by COB script "scripts/tankanotor.cob")
[f=0043154] Warning: [MapScriptToModelPieces] could not find piece named "flare2" (referenced by COB script "scripts/tankanotor.cob")
[f=0043154] Warning: [MapScriptToModelPieces] could not find piece named "sleeve" (referenced by COB script "scripts/tankanotor.cob")
[f=0043154] Warning: [MapScriptToModelPieces] could not find piece named "barrel1" (referenced by COB script "scripts/tankanotor.cob")
[f=0043154] Warning: [MapScriptToModelPieces] could not find piece named "barrel2" (referenced by COB script "scripts/tankanotor.cob")
[f=0043154] Warning: [MapScriptToModelPieces] could not find piece named "missile1" (referenced by COB script "scripts/tankanotor.cob")
[f=0043154] Warning: [MapScriptToModelPieces] could not find piece named "missile2" (referenced by COB script "scripts/tankanotor.cob")
[f=0043154] Warning: [MapScriptToModelPieces] could not find piece named "missile3" (referenced by COB script "scripts/tankanotor.cob")
[f=0043154] Warning: [MapScriptToModelPieces] could not find piece named "missile4" (referenced by COB script "scripts/tankanotor.cob")
[f=0043154] Error: [COBEngine::ShowScriptError] "unitID=13383 defName=tankanotor error="[US::SetVisibility] invalid script piece index"" outside script execution
[f=0043154] Error: [COBEngine::ShowScriptError] "unitID=13383 defName=tankanotor error="[US::SetVisibility] invalid script piece index"" outside script execution
```