### PR TITLE
Disable Temporary "Units Targetting Prioritie"

### DIFF
--- a/luarules/gadgets/unit_targetting_priorities.lua
+++ b/luarules/gadgets/unit_targetting_priorities.lua
@@ -7,7 +7,7 @@ function gadget:GetInfo()
         date = 'May 2018',
         license = 'GNU GPL, v2 or later',
         layer = -1, --must run before game_initial_spawn, because game_initial_spawn must control the return of GameSteup
-        enabled = true
+        enabled = false
     }
 end
 


### PR DESCRIPTION
Causing errors, but main reason of disabling it is to reduce new UnitCmdDesc in entire game.
It may be related with crashes too, tho spring still crash without luarules, by give all, but give all crash is maybe related with other bug.