### PR TITLE
⚙️ Deprecate sipairs, spairs and snext

### DIFF
--- a/luarules/gadgets/terrain_texture_handler.lua
+++ b/luarules/gadgets/terrain_texture_handler.lua
@@ -179,7 +179,7 @@ end
 local function changeBlockList()
 	local blockList = SYNCED.SentBlockList
 	if type(blockList) == "table" then
-		for i, v in spairs(blockList) do
+		for i, v in pairs(blockList) do
 			ChangeTextureBlock(v.x, v.z, v.tex)
 		end
 	end

--- a/luarules/gadgets/unit_morph.lua
+++ b/luarules/gadgets/unit_morph.lua
@@ -1270,8 +1270,6 @@ end
 local gameFrame;
 local SYNCED = SYNCED
 local CallAsTeam = CallAsTeam
-local spairs = spairs
-local snext = snext
 
 local GetGameFrame        = Spring.GetGameFrame
 local GetSpectatingState  = Spring.GetSpectatingState

--- a/luarules/system.lua
+++ b/luarules/system.lua
@@ -51,9 +51,9 @@ if (System == nil) then
     --  Unsynced Utilities
     --
     SYNCED  = SYNCED,
-    snext   = snext,
-    spairs  = spairs,
-    sipairs = sipairs,
+    snext   = next, -- the following 3 are deprecated, but defined in case any legacy code uses them
+    spairs  = pairs,
+    sipairs = ipairs,
 
     --
     --  Standard libraries


### PR DESCRIPTION
These are no longer needed and are the same as regular pairs etc.
Left them defined in case there's legacy code (e.g. in maps or something) using them.