### PR TITLE
Replace `CSphereParticleSpawner` with `CSimpleParticleSystem`

### DIFF
--- a/effects/arghnuke.lua
+++ b/effects/arghnuke.lua
@@ -13,7 +13,7 @@ return {
   ["smoke_column_nuke_fx_01_01"] = {
     smokin01 = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 9,
       ground             = true,
       water              = true,
@@ -45,7 +45,7 @@ return {
   ["smoke_column_nuke_fx_02_01"] = {
     smokin02 = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 90,
       ground             = true,
       water              = true,

--- a/effects/arghnuke1.lua
+++ b/effects/arghnuke1.lua
@@ -119,7 +119,7 @@ return {
   ["smoke_column_nuke_fx_02_011"] = {
     smokin02 = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 90,
       ground             = true,
       water              = true,
@@ -350,7 +350,7 @@ return {
   ["smoke_column_nuke_fx_01_011"] = {
     smokin01 = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 9,
       ground             = true,
       water              = true,

--- a/effects/arghnuke2.lua
+++ b/effects/arghnuke2.lua
@@ -44,7 +44,7 @@ return {
   ["smoke_column_nuke_fx_01_012"] = {
     smokin01 = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 9,
       ground             = true,
       water              = true,
@@ -386,7 +386,7 @@ return {
   ["smoke_column_nuke_fx_02_012"] = {
     smokin02 = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 90,
       ground             = true,
       water              = true,

--- a/effects/nuke_explosions/nuke_explo_1280.lua
+++ b/effects/nuke_explosions/nuke_explo_1280.lua
@@ -514,7 +514,7 @@ return {
   ["fireball_piece2_nuke_1280"] = {
      smokeup = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 1,
       ground             = true,
       water              = true,
@@ -542,7 +542,7 @@ return {
     },
     heatup = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 1,
       ground             = true,
       water              = true,
@@ -570,7 +570,7 @@ return {
     },
      heatup1 = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 1,
       ground             = true,
       water              = true,

--- a/effects/nuke_explosions/nuke_explo_1560.lua
+++ b/effects/nuke_explosions/nuke_explo_1560.lua
@@ -514,7 +514,7 @@ return {
   ["fireball_piece2_nuke_1560"] = {
      smokeup = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 1,
       ground             = true,
       water              = true,
@@ -542,7 +542,7 @@ return {
     },
     heatup = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 1,
       ground             = true,
       water              = true,
@@ -570,7 +570,7 @@ return {
     },
      heatup1 = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 1,
       ground             = true,
       water              = true,

--- a/effects/small_bullet_fx.lua
+++ b/effects/small_bullet_fx.lua
@@ -19,7 +19,7 @@ return {
     },
     particlesystem_dirt_small_bullet_fx = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 0,
       ground             = true,
       water              = false,


### PR DESCRIPTION
These have always been equivalent in behaviour, but the former will be getting removed in Recoil.